### PR TITLE
Custom Slack client

### DIFF
--- a/machine/core.py
+++ b/machine/core.py
@@ -119,8 +119,12 @@ class Machine:
             proxy=self._settings["HTTP_PROXY"],
         )
 
+        # Find out if the default client should be used or a custom one
+        client = self._settings.get("SLACK_CLIENT", "machine.clients.slack.SlackClient")
+        logger.info("Initializing Slack client %s...", client)
+        _, cls = import_string(client)[0]
         # Setup high-level Slack client for plugins
-        self._client = SlackClient(self._socket_mode_client, self._tz)
+        self._client = cls(self._socket_mode_client, self._tz)
         await self._client.setup()
 
     # TODO: factor out plugin registration in separate class / set of functions


### PR DESCRIPTION
This change will allow to pass an importable and valid class that will be used to initialize the base `Machine` class

Missing methods and additional attributes may  be created and used.

It defaults to `machine.clients.slack.SlackClient` if there is no `SLACK_CLIENT` in `local_settings.py`